### PR TITLE
Add "Mac OS X" to OperatingSystem#fromText

### DIFF
--- a/src/main/java/eu/hansolo/jdktools/OperatingSystem.java
+++ b/src/main/java/eu/hansolo/jdktools/OperatingSystem.java
@@ -128,7 +128,7 @@ public enum OperatingSystem implements Api {
             case "-solaris", "solaris", "SOLARIS", "Solaris" -> SOLARIS;
             case "-qnx", "qnx", "QNX" -> QNX;
             case "-aix", "aix", "AIX" -> AIX;
-            case "darwin", "-darwin", "-macosx", "-MACOSX", "MacOS", "Mac OS", "mac_os", "Mac_OS", "mac-os", "Mac-OS", "mac", "MAC", "macos", "MACOS", "osx", "OSX", "macosx", "MACOSX", "Mac OSX", "mac osx" -> MACOS;
+            case "darwin", "-darwin", "-macosx", "-MACOSX", "MacOS", "Mac OS", "mac_os", "Mac_OS", "mac-os", "Mac-OS", "mac", "MAC", "macos", "MACOS", "osx", "OSX", "macosx", "MACOSX", "Mac OSX", "mac osx", "Mac OS X" -> MACOS;
             case "-win", "windows", "Windows", "WINDOWS", "win", "Win", "WIN" -> WINDOWS;
             default -> NOT_FOUND;
         };


### PR DESCRIPTION
Fixes #3

Sample test program:
```java
import eu.hansolo.jdktools.OperatingSystem;

class mac {
	public static void main(String[] args) {
		String os = System.getProperty("os.name");
		System.out.println(os);
		System.out.println(OperatingSystem.fromText(os));
	}
}
```

Running with this change on mac:
```bash
starksm@Scotts-Mac-Studio sms-jdktools % java --class-path build/libs/jdktools-17.0.41.jar mac.java
Mac OS X
{"name":"MACOS","ui_string":"Mac OS","api_string":"macos","lib_c_type":"libc"}
```
